### PR TITLE
Fix weather connector example

### DIFF
--- a/samples/node/public/discovery/metadata.json
+++ b/samples/node/public/discovery/metadata.json
@@ -1,7 +1,8 @@
 {
+  "authentication_header": "X-Weather-Authorization",
   "fields": {
     "zip": {
-      "regex": "(^\d{5}(?:[-\s]\d{4})?$)"
+      "regex": "([0-9]{5})(?:[- ][0-9]{4})?"
     }
   }
 }

--- a/samples/node/routes/weather.js
+++ b/samples/node/routes/weather.js
@@ -60,7 +60,7 @@ function toCard(zip, routingPrefix) {
                 label: "Report weather",
                 completed_label: "Weather reported successfully",
                 url: {
-                    href: `${routingPrefix}weather/reports`
+                    href: `${routingPrefix}reports`
                 },
                 type: "POST",
                 request: {


### PR DESCRIPTION
While testing an external connector, I found a couple of typos and missing
information.

This commit:

* Fixes reports action url
* Fixes escape codes in the regex
* Adds authentication_header so the example will work