### PR TITLE
APF-1298: Update cards to objects

### DIFF
--- a/schema/herocard-response-schema.json
+++ b/schema/herocard-response-schema.json
@@ -4,7 +4,7 @@
 
   "type": "object",
   "properties": {
-    "cards": {"type": "array", "items": {"$ref": "#/definitions/card"}}
+    "objects": {"type": "array", "items": {"$ref": "#/definitions/card"}}
   },
   "additionalProperties": false,
 


### PR DESCRIPTION
* Changes "cards" to "objects" for the outer response.
* Need to follow up with other object types, or a more generic structure.

Signed-off-by: John Bard <jbard@vmware.com>