### PR TITLE
APF-1298: Update sample connector

### DIFF
--- a/samples/node/public/discovery/metadata.json
+++ b/samples/node/public/discovery/metadata.json
@@ -1,5 +1,6 @@
 {
   "authorization_header": "X-Weather-Authorization",
+  "object_type": "card",
   "fields": {
     "zip": {
       "capture_group": 1,

--- a/samples/node/routes/discovery.js
+++ b/samples/node/routes/discovery.js
@@ -11,7 +11,7 @@ exports.root = function (req, res) {
     const resource = new hal.Resource();
     const base = `${protocol(req)}://${host(req)}`;
     resource.link('metadata', `${base}/discovery/metadata.json`);
-    resource.link('cards', `${base}/cards/requests`);
+    resource.link('objects', `${base}/cards/requests`);
     resource.link('image', `${base}/images/connector.png`);
     resource.link('test_auth', `${base}/test-auth`);
     res.setHeader('Content-Type', 'application/hal+json');

--- a/samples/node/routes/weather.js
+++ b/samples/node/routes/weather.js
@@ -20,7 +20,7 @@ exports.requestCards = function(req, res) {
     // We will be more lax here.
     const routingPrefix = req.headers['x-routing-prefix'] || '/';
 
-    res.json({cards: zips.map(function(zip){
+    res.json({objects: zips.map(function(zip){
       return toCard(zip, routingPrefix);
     })});
 };
@@ -29,8 +29,11 @@ exports.testAuth = function(req, res) {
   res.status(200).send();
 }
 
+let lastReported = {};
+
 exports.reportWeather = function (req, res) {
     console.log(`Reporting temperature of ${req.body.temperature} for ${req.body.zip}`);
+    lastReported[req.body.zip] = req.body.temperature;
     res.status(200).end();
 };
 
@@ -49,8 +52,9 @@ function toCard(zip, routingPrefix) {
                 {
                     type: "GENERAL",
                     title: "Temperature",
-                    description: "75"
-                }, {
+                    description: `${lastReported[zip] || '75'}`
+                },
+                {
                     type: "GENERAL",
                     title: "Conditions",
                     description: "Sunny"


### PR DESCRIPTION
* Updates sample connector to use objects instead of cards
* Adds state to the connector for better demo/testing

Signed-off-by: John Bard <jbard@vmware.com>