### PR TITLE
APF-1731: Make schemas less rigid

### DIFF
--- a/schema/connector-level-actions-schema.json
+++ b/schema/connector-level-actions-schema.json
@@ -25,7 +25,6 @@
     }
   },
   "required": ["action_key", "label", "url", "type"],
-  "additionalProperties": false,
 
   "definitions": {
 
@@ -34,8 +33,7 @@
       "properties": {
         "href": {"type": "string", "format": "uri"}
       },
-      "required": ["href"],
-      "additionalProperties": false
+      "required": ["href"]
     },
 
     "connectorActionUserInput": {
@@ -48,8 +46,7 @@
         "min_length": {"type": "integer", "minimum": 0, "description": "The minimum length of the field"},
         "max_length": {"type": "integer", "minimum": 0, "description": "The maximum length of the field"}
       },
-      "required": ["id", "label"],
-      "additionalProperties": false
+      "required": ["id", "label"]
     },
 
     "httpMethods": {

--- a/schema/herocard-request-schema.json
+++ b/schema/herocard-request-schema.json
@@ -13,6 +13,5 @@
                  "[a-z0-9_-]*": {"type": "array", "items": {"type": "string"}}
                }
     }
-  },
-  "additionalProperties": false
+  }
 }

--- a/schema/herocard-response-schema.json
+++ b/schema/herocard-response-schema.json
@@ -6,7 +6,6 @@
   "properties": {
     "objects": {"type": "array", "items": {"$ref": "#/definitions/card"}}
   },
-  "additionalProperties": false,
 
 
   "definitions": {
@@ -27,8 +26,7 @@
         "hash":         {"type": "string", "description": "A hash to help the Mobile Flows determine if this card is new or has been seen before"},
         "actions":      {"type": "array", "items": {"$ref": "#/definitions/cardAction"}},
         "tags":         {"type": "array", "items": {"type": "string"}, "description": "Arbitrary tags applied to the card"}
-      },
-      "additionalProperties": false
+      }
     },
 
     "link": {
@@ -36,8 +34,7 @@
       "properties": {
         "href": {"type": "string", "format": "uri"}
       },
-      "required": ["href"],
-      "additionalProperties": false
+      "required": ["href"]
     },
 
     "cardHeader": {
@@ -45,8 +42,7 @@
       "properties": {
         "title":    {"type": "string"},
         "subtitle": {"type": "array", "items": {"type": "string"}}
-      },
-      "additionalProperties": false
+      }
     },
 
     "cardBody": {
@@ -60,8 +56,7 @@
           "items": {"$ref": "#/definitions/cardBodyField"},
           "description": "The fields of the body, if any. Fields are rendered differently according to their type attribute"
         }
-      },
-      "additionalProperties": false
+      }
     },
 
     "cardBodyField": {
@@ -75,8 +70,7 @@
           "items": {"type": "object"},
           "description": "The content of this field, which can consist of arbitrary JSON objects. The client will use the field's type attribute to determine how to parse the content."
         }
-      },
-      "additionalProperties": false
+      }
     },
 
     "cardAction": {
@@ -103,8 +97,7 @@
         "allow_repeated" : {"type": "boolean", "description": "Whether or not the action can be clicked again after successfully completed"},
         "remove_card_on_completion" : {"type": "boolean", "description": "Whether or not clients should remove the card upon successful completion of this action"}
       },
-      "required": ["id", "action_key", "label", "completed_label", "url", "type"],
-      "additionalProperties": false
+      "required": ["id", "action_key", "label", "completed_label", "url", "type"]
     },
 
     "cardActionUserInput": {
@@ -117,8 +110,7 @@
         "min_length": {"type": "integer", "minimum": 0, "description": "The minimum length of the field"},
         "max_length": {"type": "integer", "minimum": 0, "description": "The maximum length of the field"}
       },
-      "required": ["id", "label"],
-      "additionalProperties": false
+      "required": ["id", "label"]
     },
 
     "httpMethods": {


### PR DESCRIPTION
Remove additionalProperties-false from the schemas to allow json-schema
validators to accept future versions of our schema.

When adding a new property to our schemas, supporting backward
compatibility will be very complicated if we don't allow our schemas to
be forward compatible.

Allowing additional properties lets us add new properties to the schema
without breaking existing clients/systems' validation and gives those
clients/systems time to update to the new schema.

Signed-off-by: John Bard <jbard@vmware.com>