### PR TITLE
Adding a Procfile for Heroku Deployment

### DIFF
--- a/samples/node/Procfile
+++ b/samples/node/Procfile
@@ -1,0 +1,1 @@
+web: npm start -- --port=$PORT


### PR DESCRIPTION
APF-1763 Deployment Documentation

Adding a Procfile for Heroku Deployment so that users of our documentation are not required to add a commit to the project in order to deploy.