### PR TITLE
APF-2403: Fix README curl examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,21 +15,25 @@ The Weather Connector accesses a fictitious crowd-sourced weather service to pro
 
 A client requests a weather card and the following request is forwarded to the connector:
 ```
-$ curl -H "Authorization: Bearer abcdef" \
--H "Content-Type: application/json" \
--H "Accept: application/json" \
--H "X-Routing-Prefix: /connectors/weather/" \
--X POST -d '{"tokens":{"zip":["30360"]}}' \
-https://weather-connector.acme.com/cards/requests
+$ curl -H "Authorization: Bearer mobileflows-token" \
+       -H "X-Connector-Authorization: Bearer backend-token" \
+       -H "Content-Type: application/json" \
+       -H "Accept: application/json" \
+       -H "X-Routing-Prefix: /connectors/weather/" \
+       -X POST \
+       -d '{"tokens":{"zip":["30360"]}}' \
+       https://weather-connector.acme.com/cards/requests
 ```
 The card includes current weather conditions for ZIP code 30360, as well as an action to report the current temperature. If the user chooses that action, the following request will be forwarded to the connector:
 
 ```
-$ curl -H "Authorization: Bearer abcdef" \
--H "Content-Type: application/x-www-form-urlencoded" \
--H "Accept: application/json" \
--X POST -d "zip=30360&temperature=78" \
-https://weather-connector.acme.com/reports
+$ curl -H "Authorization: Bearer mobileflows-token" \
+       -H "X-Connector-Authorization: Bearer backend-token" \
+       -H "Content-Type: application/x-www-form-urlencoded" \
+       -H "Accept: application/json" \
+       -X POST \
+       -d "zip=30360&temperature=78" \
+       https://weather-connector.acme.com/reports
 ```
 A stubbed service based on the above can be found in the [samples section](samples/node) of this project.
 


### PR DESCRIPTION
* Adds missing x-connector-authorization to the README example curls

Signed-off-by: Ryan Bard <jbard@vmware.com>