### PR TITLE
APF-2377 Add connector discovery schema.

### DIFF
--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -54,7 +54,7 @@
         "fields": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/object_input_field",
+            "$ref": "#/definitions/input_field",
             "description": "Each additional property describes an input field."
           }
         },
@@ -75,7 +75,7 @@
         "endpoint"
       ]
     },
-    "object_input_field": {
+    "input_field": {
       "type": "object",
       "properties": {
         "regex": {
@@ -88,11 +88,11 @@
         },
         "env": {
           "type": "string",
-          "description": "Environment variable to send in the request.  See Discovery in wiki."
+          "description": "To be collected from client's Environment variables and send in the request. See Discovery in wiki."
         },
         "required": {
           "type": "boolean",
-          "description": "Flag says if this input field is mandatory to produce the objects."
+          "description": "A flag says if this input field is mandatory. If client knows this field then it can include in the request for better results."
         }
       },
       "dependencies": {
@@ -124,20 +124,20 @@
             "$ref": "#/definitions/connector_action_user_input"
           }
         },
-        "request": {
+        "fields": {
           "type": "object",
           "additionalProperties": {
-            "type": ["boolean", "string", "number", "object"],
-            "properties": {
-              "env": {
-                "type": "string"
-              }
-            }
+            "$ref": "#/definitions/input_field",
+            "description": "Each additional property describes an input field."
           }
         },
         "label": {
-          "type": "string",
-          "description": "A human-readable description of the action."
+          "type": "object",
+          "description": "Localised human-readable description of the action."
+        },
+        "completed_label": {
+          "type": "object",
+          "description": "A Localised message that says if the action was success in the backend."
         },
         "type": {
           "$ref": "#/definitions/http_methods",
@@ -179,8 +179,8 @@
           "description": "The field's ID, which will be used as the key when this field is submitted."
         },
         "label": {
-          "type": "string",
-          "description": "The field's label, which will be displayed to the user to describe the expected content of the field."
+          "type": "object",
+          "description": "Localised field's label, which will be displayed to the user to describe the expected content of the field."
         },
         "format": {
           "type": "string",

--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/schema#",
   "title": "Connector discovery schema",
   "type": "object",
-  "additionalProperties": false,
   "properties": {
     "image": {
       "$ref": "#/definitions/link"
@@ -41,7 +40,6 @@
     },
     "object_type": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "doc": {
           "$ref": "#/definitions/link"
@@ -68,18 +66,6 @@
     },
     "object_input_field": {
       "type": "object",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/object_input_field_regex"
-        },
-        {
-          "$ref": "#/definitions/object_input_field_env"
-        }
-      ]
-    },
-    "object_input_field_regex": {
-      "type": "object",
-      "additionalProperties": false,
       "properties": {
         "regex": {
           "type": "string"
@@ -87,29 +73,20 @@
         "capture_group": {
           "type": "integer"
         },
-        "required": {
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "regex",
-        "capture_group"
-      ]
-    },
-    "object_input_field_env": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
         "env": {
-          "$ref": "#/definitions/input_env_variables"
+          "type": "string"
         },
         "required": {
           "type": "boolean"
         }
       },
-      "required": [
-        "env"
-      ]
+      "dependencies": {
+        "regex": {
+          "required": [
+            "capture_group"
+          ]
+        }
+      }
     },
     "actions": {
       "type": "object",
@@ -119,7 +96,6 @@
     },
     "connector_level_action": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "url": {
           "$ref": "#/definitions/link"
@@ -132,7 +108,14 @@
         },
         "request": {
           "type": "object",
-          "additionalProperties": {"$ref": "#/definitions/connector_action_request_params"}
+          "additionalProperties": {
+            "type": ["boolean", "string", "number", "object"],
+            "properties": {
+              "env": {
+                "type": "string"
+              }
+            }
+          }
         },
         "label": {
           "type": "string"
@@ -141,7 +124,7 @@
           "$ref": "#/definitions/http_methods"
         },
         "action_key": {
-          "$ref": "#/definitions/connector_action_keys"
+          "type": "string"
         },
         "metadata": {
           "type": "object"
@@ -159,13 +142,6 @@
           "user_input"
         ]
       },
-      "else": {
-        "not": {
-          "required": [
-            "user_input"
-          ]
-        }
-      },
       "required": [
         "url",
         "type",
@@ -175,7 +151,6 @@
     },
     "connector_action_user_input": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "id": {
           "type": "string"
@@ -184,7 +159,7 @@
           "type": "string"
         },
         "format": {
-          "$ref": "#/definitions/connector_action_user_input_formats"
+          "type": "string"
         },
         "select": {
           "type": "object"
@@ -216,16 +191,6 @@
         "format"
       ]
     },
-    "connector_action_request_params": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "env": {
-          "$ref": "#/definitions/input_env_variables"
-        }
-      },
-      "required": ["env"]
-    },
     "configs": {
       "type": "object",
       "additionalProperties": {
@@ -234,7 +199,6 @@
     },
     "config": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "default": {
           "type": "string"
@@ -242,99 +206,41 @@
         "type": {
           "type": "string"
         },
+        "label": {
+          "type": "object"
+        },
         "description": {
-          "type": "object",
-          "additionalProperties": {
-            "not": {
-              "type": "object"
-            }
-          }
+          "type": "object"
         },
         "validators": {
           "type": "array",
-          "items": {"$ref": "#/definitions/config_validator"}
+          "items": {
+            "$ref": "#/definitions/config_validator"
+          }
         }
       },
-      "required": ["description"]
-    },
-    "config_validator": {
-      "anyOf": [
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "type": {
-              "const": "required"
-            },
-            "description": {
-              "type": "object",
-              "additionalProperties": {
-                "not": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "required": ["type"]
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "type": {
-              "const": "regex"
-            },
-            "value": {
-              "type": "string"
-            },
-            "description": {
-              "type": "object",
-              "additionalProperties": {
-                "not": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "required": ["type", "value"]
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "type": {
-              "const": "max_length"
-            },
-            "value": {
-              "type": "integer"
-            },
-            "description": {
-              "type": "object",
-              "additionalProperties": {
-                "not": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "required": ["type", "value"]
-        }
+      "required": [
+        "type",
+        "label",
+        "description"
       ]
     },
-    "input_env_variables": {
-      "type": "string",
-      "enum": [
-        "USER_EMAIL",
-        "ENROLLMENT_IDENTIFIER",
-        "ENROLLMENT_USERNAME",
-        "ENROLLMENT_GROUP_IDENTIFIER",
-        "ENROLLMENT_DEVICE_UDID",
-        "DEVICE_IDENTIFIER",
-        "DEVICE_MODEL",
-        "DEVICE_NAME",
-        "DEVICE_SYSTEM_NAME",
-        "DEVICE_SYSTEM_VERSION",
-        "DEVICE_UI_IDIOM"
+    "config_validator": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "object"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "description"
       ]
     },
     "http_methods": {
@@ -348,22 +254,6 @@
         "POST",
         "PUT",
         "TRACE"
-      ]
-    },
-    "connector_action_keys": {
-      "type": "string",
-      "enum": [
-        "DIRECT",
-        "USER_INPUT",
-        "OPEN_IN"
-      ]
-    },
-    "connector_action_user_input_formats": {
-      "type": "string",
-      "enum": [
-        "textarea",
-        "select",
-        "email"
       ]
     }
   }

--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -137,7 +137,7 @@
         },
         "completed_label": {
           "type": "object",
-          "description": "A localized message that says whether the action was successful. Locale is the key and the message is the value.",
+          "description": "A localized message that says whether the action was successful. Locale is the key and the message is the value."
         },
         "type": {
           "$ref": "#/definitions/http_methods",

--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -107,7 +107,7 @@
       "type": "object",
       "additionalProperties": {
         "$ref": "#/definitions/connector_level_action",
-        "description": "Each additional property is a connector level action."
+        "description": "Each additional property describes about a connector level action"
       }
     },
     "connector_level_action": {
@@ -133,11 +133,11 @@
         },
         "label": {
           "type": "object",
-          "description": "Localised human-readable description of the action."
+          "description": "Localised human-readable description of the action. Locale is the key (ex. en-US, en-GB, en-IN, etc.) and the description is the value."
         },
         "completed_label": {
           "type": "object",
-          "description": "A Localised message that says if the action was success in the backend."
+          "description": "A localized message that says whether the action was successful. Locale is the key and the message is the value.",
         },
         "type": {
           "$ref": "#/definitions/http_methods",
@@ -180,15 +180,18 @@
         },
         "label": {
           "type": "object",
-          "description": "Localised field's label, which will be displayed to the user to describe the expected content of the field."
+          "description": "Localised field's label, which will be displayed to the user to describe the expected content of the field. Locale is the key and the message is the value."
         },
         "format": {
           "type": "string",
           "description": "The format type of the user input."
         },
         "select": {
-          "type": "object",
-          "description": "If the format is 'select', choices for selecting should also be specified."
+          "type": "array",
+          "description": "If the format is 'select', choices for selecting should also be specified.",
+          "items": {
+            "$ref": "#/definitions/connector_action_user_input_select"
+          }
         },
         "min_length": {
           "type": "integer",
@@ -219,6 +222,20 @@
         "format"
       ]
     },
+    "connector_action_user_input_select": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "This is used as the form value while submitting the action."
+        },
+        "label": {
+          "type": "object",
+          "description": "Localised label for the select choice. Locale is the key and the label is the value."
+        }
+      },
+      "required": ["value"]
+    },
     "configs": {
       "type": "object",
       "additionalProperties": {
@@ -239,11 +256,11 @@
         },
         "label": {
           "type": "object",
-          "description": "Localised short label for the config field, that will be displayed in the admin dashboard."
+          "description": "Localised short label for the config field, that will be displayed in the admin dashboard. Locale is the key and the message is the value."
         },
         "description": {
           "type": "object",
-          "description": "Localised description for the config field."
+          "description": "Localised description for the config field. Locale is the key and the message is the value."
         },
         "validators": {
           "type": "array",
@@ -255,8 +272,7 @@
       },
       "required": [
         "type",
-        "label",
-        "description"
+        "label"
       ]
     },
     "config_validator": {
@@ -268,7 +284,7 @@
         },
         "description": {
           "type": "object",
-          "description": "Localised description for the validator."
+          "description": "Localised description for the validator. Locale is the key and the message is the value."
         },
         "value": {
           "type": "string",

--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -4,19 +4,24 @@
   "type": "object",
   "properties": {
     "image": {
-      "$ref": "#/definitions/link"
+      "$ref": "#/definitions/link",
+      "description": "Link to a PNG image that represents connector."
     },
     "test_auth": {
-      "$ref": "#/definitions/link"
+      "$ref": "#/definitions/link",
+      "description": "Link to an endpoint that helps to test backend authorization."
     },
     "object_types": {
-      "$ref": "#/definitions/object_types"
+      "$ref": "#/definitions/object_types",
+      "description": "Object types that the connector supports."
     },
     "actions": {
-      "$ref": "#/definitions/actions"
+      "$ref": "#/definitions/actions",
+      "description": "Connector level (Global level) actions that the connector supports."
     },
     "config": {
-      "$ref": "#/definitions/configs"
+      "$ref": "#/definitions/configs",
+      "description": "Multi tenant connector config properties that admin will be prompted while configuring Mobile Flows."
     }
   },
   "definitions": {
@@ -35,29 +40,35 @@
     "object_types": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/object_type"
+        "$ref": "#/definitions/object_type",
+        "description": "Each additional property is an object type."
       }
     },
     "object_type": {
       "type": "object",
       "properties": {
         "doc": {
-          "$ref": "#/definitions/link"
+          "$ref": "#/definitions/link",
+          "description": "Link to the schema of the object type."
         },
         "fields": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/object_input_field"
+            "$ref": "#/definitions/object_input_field",
+            "description": "Each additional property describes an input field."
           }
         },
         "pollable": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "A hint for the client that polling for this object_type might produce objects containing new data."
         },
         "metadata": {
-          "type": "object"
+          "type": "object",
+          "description": "Free form key-value pairs. Can contain additional metadata about the object_type, if anything is required by client."
         },
         "endpoint": {
-          "$ref": "#/definitions/link"
+          "$ref": "#/definitions/link",
+          "description": "Link to an endpoint that produces this object_type."
         }
       },
       "required": [
@@ -68,16 +79,20 @@
       "type": "object",
       "properties": {
         "regex": {
-          "type": "string"
+          "type": "string",
+          "description": "Regular expression that can be used by client to capture valid inputs, from a text line or paragraph."
         },
         "capture_group": {
-          "type": "integer"
+          "type": "integer",
+          "description": "Which parentheses group of the regex captured text to be used."
         },
         "env": {
-          "type": "string"
+          "type": "string",
+          "description": "Environment variable to send in the request.  See Discovery in wiki."
         },
         "required": {
-          "type": "boolean"
+          "type": "boolean",
+          "description": "Flag says if this input field is mandatory to produce the objects."
         }
       },
       "dependencies": {
@@ -91,17 +106,20 @@
     "actions": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/connector_level_action"
+        "$ref": "#/definitions/connector_level_action",
+        "description": "Each additional property is a connector level action."
       }
     },
     "connector_level_action": {
       "type": "object",
       "properties": {
         "url": {
-          "$ref": "#/definitions/link"
+          "$ref": "#/definitions/link",
+          "description": "Link to the action."
         },
         "user_input": {
           "type": "array",
+          "description": "Allows the user to enter data to be submitted in this action.",
           "items": {
             "$ref": "#/definitions/connector_action_user_input"
           }
@@ -118,16 +136,20 @@
           }
         },
         "label": {
-          "type": "string"
+          "type": "string",
+          "description": "A human-readable description of the action."
         },
         "type": {
-          "$ref": "#/definitions/http_methods"
+          "$ref": "#/definitions/http_methods",
+          "description": "The HTTP method to use for submitting the action request."
         },
         "action_key": {
-          "type": "string"
+          "type": "string",
+          "description": "A key by which client understand the way to submit the action. See Discovery in wiki"
         },
         "metadata": {
-          "type": "object"
+          "type": "object",
+          "description": "Free form key-value pairs. Can contain additional metadata about the action, if anything is required by client."
         }
       },
       "if": {
@@ -153,24 +175,30 @@
       "type": "object",
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "description": "The field's ID, which will be used as the key when this field is submitted."
         },
         "label": {
-          "type": "string"
+          "type": "string",
+          "description": "The field's label, which will be displayed to the user to describe the expected content of the field."
         },
         "format": {
-          "type": "string"
+          "type": "string",
+          "description": "The format type of the user input."
         },
         "select": {
-          "type": "object"
+          "type": "object",
+          "description": "If the format is 'select', choices for selecting should also be specified."
         },
         "min_length": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "description": "The minimum length of the user entered text field."
         },
         "max_length": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "description": "The maximum length of the user entered text field."
         }
       },
       "if": {
@@ -194,26 +222,32 @@
     "configs": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/config"
+        "$ref": "#/definitions/config",
+        "description": "Each additional property is a connector level configuration."
       }
     },
     "config": {
       "type": "object",
       "properties": {
         "default": {
-          "type": "string"
+          "type": "string",
+          "description": "A default value in string for the configuration."
         },
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "Type of the value expected."
         },
         "label": {
-          "type": "object"
+          "type": "object",
+          "description": "Localised short label for the config field, that will be displayed in the admin dashboard."
         },
         "description": {
-          "type": "object"
+          "type": "object",
+          "description": "Localised description for the config field."
         },
         "validators": {
           "type": "array",
+          "description": "Optional array of validators. Admin is allowed to enter a value that validates against each of these.",
           "items": {
             "$ref": "#/definitions/config_validator"
           }
@@ -229,13 +263,16 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "type": "string",
+          "description": "Config validator type. See wiki for supported validator types."
         },
         "description": {
-          "type": "object"
+          "type": "object",
+          "description": "Localised description for the validator."
         },
         "value": {
-          "type": "string"
+          "type": "string",
+          "description": "A value that can be associated with some of the validator types. See Wiki for examples."
         }
       },
       "required": [

--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -1,0 +1,370 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "Connector discovery schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "image": {
+      "$ref": "#/definitions/link"
+    },
+    "test_auth": {
+      "$ref": "#/definitions/link"
+    },
+    "object_types": {
+      "$ref": "#/definitions/object_types"
+    },
+    "actions": {
+      "$ref": "#/definitions/actions"
+    },
+    "config": {
+      "$ref": "#/definitions/configs"
+    }
+  },
+  "definitions": {
+    "link": {
+      "type": "object",
+      "properties": {
+        "href": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "required": [
+        "href"
+      ]
+    },
+    "object_types": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/object_type"
+      }
+    },
+    "object_type": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "doc": {
+          "$ref": "#/definitions/link"
+        },
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/object_input_field"
+          }
+        },
+        "pollable": {
+          "type": "boolean"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "endpoint": {
+          "$ref": "#/definitions/link"
+        }
+      },
+      "required": [
+        "endpoint"
+      ]
+    },
+    "object_input_field": {
+      "type": "object",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/object_input_field_regex"
+        },
+        {
+          "$ref": "#/definitions/object_input_field_env"
+        }
+      ]
+    },
+    "object_input_field_regex": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "regex": {
+          "type": "string"
+        },
+        "capture_group": {
+          "type": "integer"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "regex",
+        "capture_group"
+      ]
+    },
+    "object_input_field_env": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "$ref": "#/definitions/input_env_variables"
+        },
+        "required": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "env"
+      ]
+    },
+    "actions": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/connector_level_action"
+      }
+    },
+    "connector_level_action": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "$ref": "#/definitions/link"
+        },
+        "user_input": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/connector_action_user_input"
+          }
+        },
+        "request": {
+          "type": "object",
+          "additionalProperties": {"$ref": "#/definitions/connector_action_request_params"}
+        },
+        "label": {
+          "type": "string"
+        },
+        "type": {
+          "$ref": "#/definitions/http_methods"
+        },
+        "action_key": {
+          "$ref": "#/definitions/connector_action_keys"
+        },
+        "metadata": {
+          "type": "object"
+        }
+      },
+      "if": {
+        "properties": {
+          "action_key": {
+            "const": "USER_INPUT"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "user_input"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "user_input"
+          ]
+        }
+      },
+      "required": [
+        "url",
+        "type",
+        "label",
+        "action_key"
+      ]
+    },
+    "connector_action_user_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        },
+        "format": {
+          "$ref": "#/definitions/connector_action_user_input_formats"
+        },
+        "select": {
+          "type": "object"
+        },
+        "min_length": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "max_length": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "if": {
+        "properties": {
+          "format": {
+            "const": "select"
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "select"
+        ]
+      },
+      "required": [
+        "id",
+        "label",
+        "format"
+      ]
+    },
+    "connector_action_request_params": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "env": {
+          "$ref": "#/definitions/input_env_variables"
+        }
+      },
+      "required": ["env"]
+    },
+    "configs": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/config"
+      }
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "object",
+          "additionalProperties": {
+            "not": {
+              "type": "object"
+            }
+          }
+        },
+        "validators": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/config_validator"}
+        }
+      },
+      "required": ["description"]
+    },
+    "config_validator": {
+      "anyOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "const": "required"
+            },
+            "description": {
+              "type": "object",
+              "additionalProperties": {
+                "not": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "required": ["type"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "const": "regex"
+            },
+            "value": {
+              "type": "string"
+            },
+            "description": {
+              "type": "object",
+              "additionalProperties": {
+                "not": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "required": ["type", "value"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "const": "max_length"
+            },
+            "value": {
+              "type": "integer"
+            },
+            "description": {
+              "type": "object",
+              "additionalProperties": {
+                "not": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "required": ["type", "value"]
+        }
+      ]
+    },
+    "input_env_variables": {
+      "type": "string",
+      "enum": [
+        "USER_EMAIL",
+        "ENROLLMENT_IDENTIFIER",
+        "ENROLLMENT_USERNAME",
+        "ENROLLMENT_GROUP_IDENTIFIER",
+        "ENROLLMENT_DEVICE_UDID",
+        "DEVICE_IDENTIFIER",
+        "DEVICE_MODEL",
+        "DEVICE_NAME",
+        "DEVICE_SYSTEM_NAME",
+        "DEVICE_SYSTEM_VERSION",
+        "DEVICE_UI_IDIOM"
+      ]
+    },
+    "http_methods": {
+      "type": "string",
+      "enum": [
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "PUT",
+        "TRACE"
+      ]
+    },
+    "connector_action_keys": {
+      "type": "string",
+      "enum": [
+        "DIRECT",
+        "USER_INPUT",
+        "OPEN_IN"
+      ]
+    },
+    "connector_action_user_input_formats": {
+      "type": "string",
+      "enum": [
+        "textarea",
+        "select",
+        "email"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Connector discovery schema.

- Didn't copy-paste the CLA schema, as it seems to have some minor issues.
- Add property descriptions
- Fix CLA schema, for localization, completed_label.
- Object types and CLA describe input fields in a similar way.
- An example discovery JSON - https://github.com/vmware-samples/card-connectors-guide/pull/36#issuecomment-530043663

ToDo:
- Update the wiki to point a link to this.
- Delete/Fix the existing CLA schema ?