### PR TITLE
APF-2607 Regex capture group is optional.

### DIFF
--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -104,9 +104,9 @@
         }
       },
       "dependencies": {
-        "regex": {
+        "capture_group": {
           "required": [
-            "capture_group"
+            "regex"
           ]
         }
       }


### PR DESCRIPTION
The "capture_group" property is optional. 
But to specify a capture group, there should be at least a regex property.