### PR TITLE
APF-3378 Define a schema for action failure response.

### DIFF
--- a/schema/action-failure-response-schema.json
+++ b/schema/action-failure-response-schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "Action failure response schema",
+  "type": "object",
+  "properties": {
+    "title": {"type": "string", "description": "Short message on what happened with the action." },
+    "error_message": {"type": "string", "description": "An explanation about why the action was failed to execute. If applicable, also explain what user could do." },
+    "links": {"type": "array", "items": {"$ref": "#/definitions/openInLink" }, "description": "An optional array of links which explains in detail about action failure and/or how to fix them."},
+    "actions": {"type": "array", "items": {"$ref": "#/definitions/openInAction" }, "description": "Optionally give a link to the backend where necessary changes can be done, so that action would work."}
+  },
+
+  "required": ["title", "error_message"],
+
+  "definitions": {
+    "link": {
+      "type": "object",
+      "properties": {
+        "href": {"type": "string", "format": "uri"}
+      },
+      "required": ["href"]
+    },
+
+    "openInLink": {
+      "type": "object",
+      "properties": {
+        "href": {"type": "string", "format": "uri"},
+        "text": {"type": "string", "description": "A short description about this link or write how this will be useful for the user."}
+      },
+      "required": ["href", "text"]
+    },
+
+    "openInAction": {
+      "type": "object",
+      "properties": {
+        "label": {"type": "string", "description": "A description about this action."},
+        "primary": {"type": "boolean", "description": "Is it a primary action and should be colored differently than the non-primary actions"},
+        "url": {"$ref": "#/definitions/link", "description": "Link to the action."},
+        "remove_card_on_completion" : {"type": "boolean", "description": "Whether or not clients should remove the card upon successful completion of this action"}
+      },
+      "required": ["label", "url"]
+    }
+  }
+}

--- a/schema/action-failure-response-schema.json
+++ b/schema/action-failure-response-schema.json
@@ -5,7 +5,6 @@
   "properties": {
     "title": {"type": "string", "description": "Short message on what happened with the action." },
     "error_message": {"type": "string", "description": "An explanation about why the action was failed to execute. If applicable, also explain what user could do." },
-    "links": {"type": "array", "items": {"$ref": "#/definitions/openInLink" }, "description": "An optional array of links which explains in detail about action failure and/or how to fix them."},
     "actions": {"type": "array", "items": {"$ref": "#/definitions/openInAction" }, "description": "Optionally give a link to the backend where necessary changes can be done, so that action would work."}
   },
 
@@ -18,15 +17,6 @@
         "href": {"type": "string", "format": "uri"}
       },
       "required": ["href"]
-    },
-
-    "openInLink": {
-      "type": "object",
-      "properties": {
-        "href": {"type": "string", "format": "uri"},
-        "text": {"type": "string", "description": "A short description about this link or write how this will be useful for the user."}
-      },
-      "required": ["href", "text"]
     },
 
     "openInAction": {


### PR DESCRIPTION
I'm yet to raise a PR for documentation, but the idea here is that connector can optionally include a body when it rejects actions with 4xx response status. If the body matches with the schema defined here, Hub would consider displaying to the user. Otherwise Hub would continue to show the generic static message like today.

