### PR TITLE
Added new properties to object_type

### DIFF
--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -80,6 +80,17 @@
           "type": "boolean",
           "description": "A hint for the client that object_type is post-hire capable. Default value is true."
         },
+        "supported_actions": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/supported_action",
+                "description": "Each additional property is a supported action. Key is a unique string id to associate it with a single action-template in the quick_actions object"
+              }
+            ]
+          }
+        },
         "metadata": {
           "type": "object",
           "description": "Free form key-value pairs. Can contain additional metadata about the object_type, if anything is required by client."
@@ -118,6 +129,19 @@
           "required": [
             "regex"
           ]
+        }
+      }
+    },
+    "supported_action": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "object",
+          "description": "Localised name for the action. Locale is the key and the label is the value."
+        },
+        "category": {
+          "type": "string",
+          "description": "A category name for the action. This helps client to categorize the action into a separate view section."
         }
       }
     },

--- a/schema/connector-discovery-schema.json
+++ b/schema/connector-discovery-schema.json
@@ -91,6 +91,17 @@
             ]
           }
         },
+        "supported_workflows": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/supported_workflow",
+                "description": "Each additional property is a supported chatbot workflow. Key is the unique workflowId to associate it with a single workflow in the botDiscovery object"
+              }
+            ]
+          }
+        },
         "metadata": {
           "type": "object",
           "description": "Free form key-value pairs. Can contain additional metadata about the object_type, if anything is required by client."
@@ -142,6 +153,15 @@
         "category": {
           "type": "string",
           "description": "A category name for the action. This helps client to categorize the action into a separate view section."
+        }
+      }
+    },
+    "supported_workflow": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "object",
+          "description": "Localised name for the chatbot workflow. Locale is the key and the label is the value."
         }
       }
     },


### PR DESCRIPTION
1) For quick actions to specify supported actions in the discovery metadata. So that it can be presented to Hub user, without involving backend token/fallback URL problems. 

2) For chatbot workflows to specify supported workflows in the discovery metadata. Helps chatbot service to solve the problems around the fallback URL. 