### PR TITLE
APF-3566: Add display_content to user input field

### DIFF
--- a/schema/herocard-response-schema.json
+++ b/schema/herocard-response-schema.json
@@ -176,12 +176,13 @@
     "cardActionUserInput": {
       "type": "object",
       "properties": {
-        "id":         {"type": "string", "description": "The field's ID, which will be used as the key when this field is submitted"},
-        "label":      {"type": "string", "description": "The field's label, which will be displayed to the user to describe the expected content of the field"},
-        "format":     {"type": "string", "description": "The type of the user input"},
-        "options":    {"type": "object", "description": "Options to present when format is select."},
-        "min_length": {"type": "integer", "minimum": 0, "description": "The minimum length of the field"},
-        "max_length": {"type": "integer", "minimum": 0, "description": "The maximum length of the field"}
+        "id":              {"type": "string", "description": "The field's ID, which will be used as the key when this field is submitted"},
+        "label":           {"type": "string", "description": "The field's label, which will be displayed to the user to describe the expected content of the field"},
+        "format":          {"type": "string", "description": "The type of the user input"},
+        "display_content": {"type": "string", "description": "Content to be displayed with the user input field to further explain or prompt it"},
+        "options":         {"type": "object", "description": "Options to present when format is select."},
+        "min_length":      {"type": "integer", "minimum": 0, "description": "The minimum length of the field"},
+        "max_length":      {"type": "integer", "minimum": 0, "description": "The maximum length of the field"}
       },
       "required": ["id", "label"]
     },


### PR DESCRIPTION
Add the display_content to a user input form field to allow explanation
on what is being prompted.  This will allow more real estate for details
than a label would offer.

Signed-off-by: Ryan Bard <jbard@vmware.com>